### PR TITLE
WIP: v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Common flags:
       --id string            MQTT client ID (default "mqtt-test-bssJjZUs1vhTvf6KpTpTLw")
   -q, --quiet                Quiet mode, only print results
   -s, --server stringArray   MQTT endpoint as username:password@host:port (default [tcp://localhost:1883])
+      --timeout duration     Timeout for the test (default 10s)
       --version              version for mqtt-test
   -v, --very-verbose         Very verbose, print everything we can
 ```
@@ -40,7 +41,7 @@ Flags:
 --retain           Mark each published message as retained
 --size int         Approximate size of each message (pub adds a timestamp)
 --timestamp        Prepend a timestamp to each message
---topic string     Base topic (prefix) to publish into (/{n} will be added if --topics > 0) (default "mqtt-test/fIqfOq5Lg5wk636V4sLXoc")
+--topic string     Base topic (prefix) to publish into (/{n} will be added if --topics > 0)
 --topics int       Cycle through NTopics appending "/{n}"
 ```
 
@@ -56,7 +57,8 @@ Flags:
 --repeat int        Subscribe, receive retained messages, and unsubscribe N times (default 1)
 --retained int      Expect to receive this many retained messages
 --subscribers int   Number of subscribers to run concurrently (default 1)
---topic string      Base topic for the test, will subscribe to {topic}/+
+--timestamp         Expect a timestamp in the payload and use it to calculate receive time
+--topic string      Topic to subscribe to
 ```
 
 ##### pubsub
@@ -64,11 +66,14 @@ Flags:
 Publishes N messages, and waits for all of them to be received by subscribers. Measures end-end delivery time on the messages. Used with `--num-subscribers` can run several concurrent subscriber connections.
 
 ```
---messages int      Number of messages to publish and receive (default 1)
---qos int           MQTT QOS
---size int          Approximate size of each message (pub adds a timestamp)
---subscribers int   Number of subscribers to run concurrently (default 1)
---topic string      Topic to publish and subscribe to (default "mqtt-test/JPrbNU6U3IbVQLIyazkP4y")
+--messages int        Number of messages to publish and receive (default 1)
+--mps int             Publish mps messages per second; 0 means no delay (default 1000)
+--pub-server string   Server to publish to. Defaults to the first server in --servers
+--qos int             MQTT QOS
+--size int            Message extra payload size (in addition to the JSON timestamp)
+--subscribers int     Number of subscribers to run concurrently (default 1)
+--topic string        Topic (or base topic if --topics > 1)
+--topics int          Number of topics to use, If more than one will add /1, /2, ... to --topic when publishing, and subscribe to topic/+ (default 1)
 ```
 
 ##### subret
@@ -78,10 +83,12 @@ topics N times. Measures time to SUBACK and to all retained messages received.
 Used with `--subscribers` can run several concurrent subscriber connections.
 
 ```
---qos int           MQTT QOS
---repeat int        Subscribe, receive retained messages, and unsubscribe N times (default 1)
---size int          Approximate size of each message (pub adds a timestamp)
---subscribers int   Number of subscribers to run concurrently (default 1)
---topic string      Base topic (prefix) for the test (default "mqtt-test/yNkmAFnFHETSGnQJNjwGdN")
---topics int        Number of sub-topics to publish retained messages to (default 1)
+--mps int                  Publish mps messages per second; 0 means no delay (default 1000)
+--pub-server stringArray   Server(s) to publish to. Defaults to --servers
+--qos int                  MQTT QOS for subscriptions. Messages are published as QOS1.
+--repeat int               Subscribe, receive retained messages, and unsubscribe N times (default 1)
+--retained int             Number of retained messages to publish and receive (default 1)
+--size int                 Message payload size
+--subscribers int          Number of subscribers to run concurrently (default 1)
+--topic string             base topic (if --retaned > 1 will be published to topic/1, topic/2, ...)
 ```

--- a/command-pub.go
+++ b/command-pub.go
@@ -14,19 +14,14 @@
 package main
 
 import (
-	"encoding/json"
-	"log"
-	"os"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 )
 
 type pubCommand struct {
-	publisher
+	opts       publisher
 	publishers int
-	timestamp  bool
 }
 
 func newPubCommand() *cobra.Command {
@@ -39,59 +34,30 @@ func newPubCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	// Message options
-	cmd.Flags().StringVar(&c.topic, "topic", defaultTopic(), "Base topic (prefix) to publish into (/{n} will be added if --topics > 0)")
-	cmd.Flags().IntVar(&c.qos, "qos", DefaultQOS, "MQTT QOS")
-	cmd.Flags().IntVar(&c.size, "size", 0, "Approximate size of each message (pub adds a timestamp)")
-	cmd.Flags().BoolVar(&c.retain, "retain", false, "Mark each published message as retained")
-	cmd.Flags().BoolVar(&c.timestamp, "timestamp", false, "Prepend a timestamp to each message")
-
-	// Test options
-	cmd.Flags().IntVar(&c.mps, "mps", 1000, `Publish mps messages per second; 0 means no delay`)
-	cmd.Flags().IntVar(&c.messages, "messages", 1, "Number of transactions to run, see the specific command")
+	cmd.Flags().IntVar(&c.opts.messages, "messages", 1, "Number of transactions to run, see the specific command")
+	cmd.Flags().IntVar(&c.opts.mps, "mps", 1000, `Publish mps messages per second; 0 means no delay`)
+	cmd.Flags().IntVar(&c.opts.qos, "qos", DefaultQOS, "MQTT QOS")
+	cmd.Flags().BoolVar(&c.opts.retain, "retain", false, "Mark each published message as retained")
+	cmd.Flags().IntVar(&c.opts.size, "size", 0, "Approximate size of each message (pub adds a timestamp)")
+	cmd.Flags().BoolVar(&c.opts.timestamp, "timestamp", false, "Prepend a timestamp to each message")
+	cmd.Flags().StringVar(&c.opts.topic, "topic", defaultTopic(), "Base topic (prefix) to publish into (/{n} will be added if --topics > 0)")
+	cmd.Flags().IntVar(&c.opts.topics, "topics", 0, `Cycle through NTopics appending "/{n}"`)
 	cmd.Flags().IntVar(&c.publishers, "publishers", 1, `Number of publishers to run concurrently, at --mps each`)
-	cmd.Flags().IntVar(&c.topics, "topics", 0, `Cycle through NTopics appending "/{n}"`)
 
 	return cmd
 }
 
 func (c *pubCommand) run(_ *cobra.Command, _ []string) {
-	msgChan := make(chan *Stat)
-	errChan := make(chan error)
-
+	doneCh := make(chan struct{})
 	for i := 0; i < c.publishers; i++ {
-		p := c.publisher // copy
-		p.clientID = ClientID + "-" + strconv.Itoa(i)
-		go p.publish(msgChan, errChan, c.timestamp)
-	}
-
-	pubOps := 0
-	pubNS := time.Duration(0)
-	pubBytes := int64(0)
-	timeout := time.NewTimer(Timeout)
-	defer timeout.Stop()
-
-	// get back 1 report per publisher
-	for n := 0; n < c.publishers; {
-		select {
-		case stat := <-msgChan:
-			pubOps += stat.Ops
-			pubNS += stat.NS["pub"]
-			pubBytes += stat.Bytes
-			n++
-
-		case err := <-errChan:
-			log.Fatalf("Error: %v", err)
-
-		case <-timeout.C:
-			log.Fatalf("Error: timeout waiting for publishers")
+		p := c.opts // copy
+		p.dials = dials(Servers)
+		p.clientID = ClientID
+		if c.publishers > 1 {
+			p.clientID = p.clientID + "-" + strconv.Itoa(i)
 		}
+		go p.publish(doneCh)
 	}
 
-	bb, _ := json.Marshal(Stat{
-		Ops:   pubOps,
-		NS:    map[string]time.Duration{"pub": pubNS},
-		Bytes: pubBytes,
-	})
-	os.Stdout.Write(bb)
+	waitN(doneCh, c.publishers, "publisher to finish")
 }

--- a/command-sub.go
+++ b/command-sub.go
@@ -14,142 +14,66 @@
 package main
 
 import (
-	"encoding/json"
-	"log"
-	"os"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 )
 
 type subCommand struct {
-	// message options
-	messageOpts
-
-	// test options
-	repeat          int
-	subscribers     int
-	expectRetained  int
-	expectPublished int
+	opts        receiver
+	subscribers int
 }
 
 func newSubCommand() *cobra.Command {
 	c := &subCommand{}
-
 	cmd := &cobra.Command{
 		Use:   "sub [--flags...]",
 		Short: "Subscribe, receive all messages, unsubscribe, {repeat} times.",
 		Run:   c.run,
 		Args:  cobra.NoArgs,
 	}
-
-	cmd.Flags().StringVar(&c.topic, "topic", "", "Base topic for the test, will subscribe to {topic}/+")
-	cmd.Flags().IntVar(&c.qos, "qos", DefaultQOS, "MQTT QOS")
-	cmd.Flags().IntVar(&c.repeat, "repeat", 1, "Subscribe, receive retained messages, and unsubscribe N times")
+	cmd.Flags().IntVar(&c.opts.expectPublished, "messages", 0, `Expect to receive this many published messages`)
+	cmd.Flags().IntVar(&c.opts.expectRetained, "retained", 0, `Expect to receive this many retained messages`)
+	cmd.Flags().BoolVar(&c.opts.expectTimestamp, "timestamp", false, "Expect a timestamp in the payload and use it to calculate receive time")
+	cmd.Flags().IntVar(&c.opts.qos, "qos", DefaultQOS, "MQTT QOS")
+	cmd.Flags().IntVar(&c.opts.repeat, "repeat", 1, "Subscribe, receive (retained) messages, and unsubscribe this many times")
+	cmd.Flags().StringVar(&c.opts.topic, "topic", defaultTopic(), "Topic to subscribe to")
 	cmd.Flags().IntVar(&c.subscribers, "subscribers", 1, `Number of subscribers to run concurrently`)
-	cmd.Flags().IntVar(&c.expectRetained, "retained", 0, `Expect to receive this many retained messages`)
-	cmd.Flags().IntVar(&c.expectPublished, "messages", 0, `Expect to receive this many published messages`)
+
+	cmd.PreRun = func(_ *cobra.Command, _ []string) {
+		prefix := c.opts.topic
+		i := len(prefix) - 1
+		for ; i >= 0; i-- {
+			if prefix[i] != '/' && prefix[i] != '#' && prefix[i] != '+' {
+				break
+			}
+		}
+		c.opts.filterPrefix = prefix[:i+1]
+	}
 
 	return cmd
 }
 
 func (c *subCommand) run(_ *cobra.Command, _ []string) {
-	total := runSubPrepublishRetained(c.subscribers, c.repeat, c.expectRetained, c.expectPublished, c.messageOpts, false)
-	bb, _ := json.Marshal(total)
-	os.Stdout.Write(bb)
-}
+	doneCh := make(chan struct{})
 
-func runSubPrepublishRetained(
-	nSubscribers int,
-	repeat int,
-	expectRetained,
-	expectPublished int,
-	messageOpts messageOpts,
-	prepublishRetained bool,
-) *Stat {
-	errCh := make(chan error)
-	receiverReadyCh := make(chan struct{})
-	statsCh := make(chan *Stat)
-
-	if prepublishRetained {
-		if expectPublished != 0 {
-			log.Fatalf("Error: --messages is not supported with --retained")
-		}
-
-		// We need to wait for all prepublished retained messages to be processed.
-		// To ensure, subscribe once before we pre-publish and receive all published
-		// messages.
-		r := &receiver{
-			clientID:        ClientID + "-sub-init",
-			filterPrefix:    messageOpts.topic,
-			topic:           messageOpts.topic + "/+",
-			qos:             messageOpts.qos,
-			expectRetained:  0,
-			expectPublished: expectRetained,
-			repeat:          1,
-		}
-		go r.receive(receiverReadyCh, statsCh, errCh)
-		<-receiverReadyCh
-
-		// Pre-publish retained messages.
-		p := &publisher{
-			clientID:    ClientID + "-pub",
-			messages:    expectRetained,
-			topics:      expectRetained,
-			messageOpts: messageOpts,
-		}
-		p.messageOpts.retain = true
-		go p.publish(nil, errCh, true)
-
-		// wait for the initial subscription to have received all messages
-		timeout := time.NewTimer(Timeout)
-		defer timeout.Stop()
-		select {
-		case err := <-errCh:
-			log.Fatalf("Error: %v", err)
-		case <-timeout.C:
-			log.Fatalf("Error: timeout waiting for messages in initial subscription")
-		case <-statsCh:
-			// all received
-		}
-
+	counter := 0
+	if len(Servers) > 1 || c.subscribers > 1 {
+		counter = 1
 	}
 
-	// Connect all subscribers (and subscribe to a wildcard topic that includes
-	// all published retained messages).
-	for i := 0; i < nSubscribers; i++ {
-		r := &receiver{
-			clientID:        ClientID + "-sub-" + strconv.Itoa(i),
-			filterPrefix:    messageOpts.topic,
-			topic:           messageOpts.topic + "/+",
-			qos:             messageOpts.qos,
-			expectRetained:  expectRetained,
-			expectPublished: expectPublished,
-			repeat:          repeat,
-		}
-		go r.receive(nil, statsCh, errCh)
-	}
-
-	// wait for the stats
-	total := &Stat{
-		NS: make(map[string]time.Duration),
-	}
-	timeout := time.NewTimer(Timeout)
-	defer timeout.Stop()
-	for i := 0; i < nSubscribers*repeat; i++ {
-		select {
-		case stat := <-statsCh:
-			total.Ops += stat.Ops
-			total.Bytes += stat.Bytes
-			for k, v := range stat.NS {
-				total.NS[k] += v
+	for _, d := range dials(Servers) {
+		for i := 0; i < c.subscribers; i++ {
+			r := c.opts // copy
+			r.clientID = ClientID
+			if counter != 0 {
+				r.clientID = r.clientID + "-" + strconv.Itoa(counter)
+				counter++
 			}
-		case err := <-errCh:
-			log.Fatalf("Error: %v", err)
-		case <-timeout.C:
-			log.Fatalf("Error: timeout waiting for messages")
+			r.dial = d
+			go r.receive(nil, doneCh)
 		}
 	}
-	return total
+
+	waitN(doneCh, c.subscribers*len(Servers), "all subscribers to finish")
 }

--- a/command-subret.go
+++ b/command-subret.go
@@ -14,25 +14,20 @@
 package main
 
 import (
-	"encoding/json"
-	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
 
 type subretCommand struct {
-	// message options
-	messageOpts
-
-	// test options
-	repeat      int
+	pubOpts     publisher
+	subOpts     receiver
+	pubServers  []string
 	subscribers int
-	messages    int
 }
 
 func newSubRetCommand() *cobra.Command {
 	c := &subretCommand{}
-
 	cmd := &cobra.Command{
 		Use:   "subret [--flags...]",
 		Short: "Publish {topics} retained messages, subscribe {repeat} times, and receive all retained messages.",
@@ -40,18 +35,76 @@ func newSubRetCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	cmd.Flags().StringVar(&c.topic, "topic", defaultTopic(), "Base topic (prefix) for the test")
-	cmd.Flags().IntVar(&c.qos, "qos", DefaultQOS, "MQTT QOS")
-	cmd.Flags().IntVar(&c.size, "size", 0, "Approximate size of each message (pub adds a timestamp)")
-	cmd.Flags().IntVar(&c.repeat, "repeat", 1, "Subscribe, receive retained messages, and unsubscribe N times")
+	cmd.Flags().IntVar(&c.pubOpts.messages, "retained", 1, "Number of retained messages to publish and receive")
+	cmd.Flags().IntVar(&c.pubOpts.mps, "mps", 1000, `Publish mps messages per second; 0 means no delay`)
+	cmd.Flags().IntVar(&c.pubOpts.size, "size", 0, "Message payload size")
+	cmd.Flags().StringVar(&c.pubOpts.topic, "topic", defaultTopic(), "base topic (if --retained > 1 will be published to topic/1, topic/2, ...)")
+
+	cmd.Flags().IntVar(&c.subOpts.qos, "qos", DefaultQOS, "MQTT QOS for subscriptions. Messages are published as QOS1.")
+	cmd.Flags().IntVar(&c.subOpts.repeat, "repeat", 1, "Subscribe, receive retained messages, and unsubscribe N times")
+
+	cmd.Flags().StringArrayVar(&c.pubServers, "pub-server", nil, "Server(s) to publish to. Defaults to --servers")
 	cmd.Flags().IntVar(&c.subscribers, "subscribers", 1, `Number of subscribers to run concurrently`)
-	cmd.Flags().IntVar(&c.messages, "topics", 1, `Number of sub-topics to publish retained messages to`)
+
+	cmd.PreRun = func(_ *cobra.Command, _ []string) {
+		c.pubOpts.clientID = ClientID + "-pub"
+		if len(c.pubServers) > 0 {
+			c.pubOpts.dials = dials(c.pubServers)
+		} else {
+			c.pubOpts.dials = dials(Servers)
+		}
+		c.pubOpts.retain = true
+		c.pubOpts.timestamp = false
+		c.pubOpts.topics = c.pubOpts.messages
+		c.pubOpts.qos = c.subOpts.qos
+		// Always use at least QoS1 to ensure retained is processed.
+		if c.pubOpts.qos < 1 {
+			c.pubOpts.qos = 1
+		}
+		// Always send at least 1 byte so the messages are not treated as "retained delete".
+		if c.pubOpts.size < 1 {
+			c.pubOpts.size = 1
+		}
+
+		c.subOpts.clientID = ClientID + "-sub"
+		c.subOpts.expectRetained = c.pubOpts.messages
+		c.subOpts.expectTimestamp = false
+		c.subOpts.filterPrefix = c.pubOpts.topic
+		c.subOpts.topic = c.pubOpts.topic
+		if c.pubOpts.topics > 1 {
+			c.subOpts.topic = c.pubOpts.topic + "/+"
+		}
+	}
 
 	return cmd
 }
 
 func (c *subretCommand) run(_ *cobra.Command, _ []string) {
-	total := runSubPrepublishRetained(c.subscribers, c.repeat, c.messages, 0, c.messageOpts, true)
-	bb, _ := json.Marshal(total)
-	os.Stdout.Write(bb)
+	// Pre-publish retained messages, and wait for all to be received.
+	c.pubOpts.publish(nil)
+
+	counter := 0
+	if len(Servers) > 1 || c.subscribers > 1 {
+		counter = 1
+	}
+	N := c.subscribers * len(Servers)
+	doneCh := make(chan struct{})
+
+	// Connect all subscribers and subscribe. Wait for all subscriptions to
+	// signal ready before publishing.
+	for _, d := range dials(Servers) {
+		for i := 0; i < c.subscribers; i++ {
+			r := c.subOpts // copy
+			if r.clientID == "" {
+				r.clientID = ClientID
+			}
+			if counter != 0 {
+				r.clientID = r.clientID + "-" + strconv.Itoa(counter)
+				counter++
+			}
+			r.dial = d
+			go r.receive(nil, doneCh)
+		}
+	}
+	waitN(doneCh, N, "subscribers to finish")
 }

--- a/main.go
+++ b/main.go
@@ -14,12 +14,9 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"os"
-	"sync"
 	"time"
 
 	paho "github.com/eclipse/paho.mqtt.golang"
@@ -29,11 +26,10 @@ import (
 
 const (
 	Name                     = "mqtt-test"
-	Version                  = "v0.1.0"
+	Version                  = "v0.2.0"
 	DefaultServer            = "tcp://localhost:1883"
 	DefaultQOS               = 0
-	Timeout                  = 10 * time.Second
-	DisconnectCleanupTimeout = 500 // milliseconds
+	DisconnectCleanupTimeout = 2000 // milliseconds
 )
 
 var (
@@ -43,28 +39,36 @@ var (
 	Servers  []string
 	Username string
 	Verbose  bool
+	Timeout  time.Duration
 )
 
-var disconnectedWG = sync.WaitGroup{}
+type Stat struct {
+	Ops   int           `json:"ops"`
+	NS    time.Duration `json:"ns"`
+	Bytes int64         `json:"bytes"`
+}
 
 func main() {
 	_ = mainCmd.Execute()
 	disconnectedWG.Wait()
+
+	printTotals()
 }
 
 var mainCmd = &cobra.Command{
-	Use:     Name + " [pub|sub|subret|...] [--flags...]",
+	Use:     Name + " [pub|sub|test...] [--flags...]",
 	Short:   "MQTT Test and Benchmark Utility",
 	Version: Version,
 }
 
 func init() {
 	mainCmd.PersistentFlags().StringVar(&ClientID, "id", Name+"-"+nuid.Next(), "MQTT client ID")
+	mainCmd.PersistentFlags().DurationVar(&Timeout, "timeout", 10*time.Second, "Timeout for the test")
 	mainCmd.PersistentFlags().StringArrayVarP(&Servers, "server", "s", []string{DefaultServer}, "MQTT endpoint as username:password@host:port")
 	mainCmd.PersistentFlags().BoolVarP(&Quiet, "quiet", "q", false, "Quiet mode, only print results")
 	mainCmd.PersistentFlags().BoolVarP(&Verbose, "very-verbose", "v", false, "Very verbose, print everything we can")
 
-	mainCmd.PersistentFlags().StringArrayVar(&Servers, "servers", []string{DefaultServer}, "MQTT endpoint as username:password@host:port")
+	oldServers := mainCmd.PersistentFlags().StringArray("servers", nil, "MQTT endpoint as username:password@host:port")
 	mainCmd.PersistentFlags().MarkDeprecated("servers", "please use server instead.")
 
 	mainCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
@@ -72,13 +76,16 @@ func init() {
 		if Quiet {
 			Verbose = false
 			log.SetOutput(io.Discard)
-		}
-		if !Quiet {
+		} else {
 			paho.ERROR = log.New(os.Stderr, "[MQTT ERROR] ", 0)
 		}
 		if Verbose {
 			paho.WARN = log.New(os.Stderr, "[MQTT WARN] ", 0)
 			paho.DEBUG = log.New(os.Stderr, "[MQTT DEBUG] ", 0)
+		}
+
+		if len(*oldServers) > 0 {
+			Servers = *oldServers
 		}
 	}
 
@@ -88,49 +95,4 @@ func init() {
 	mainCmd.AddCommand(newSubRetCommand())
 }
 
-type PubValue struct {
-	Seq       int   `json:"seq"`
-	Timestamp int64 `json:"timestamp"`
-}
-
-type Stat struct {
-	Ops   int                      `json:"ops"`
-	NS    map[string]time.Duration `json:"ns"`
-	Bytes int64                    `json:"bytes"`
-}
-
-func randomPayload(sz int) []byte {
-	const ch = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@$#%^&*()"
-	b := make([]byte, sz)
-	for i := range b {
-		b[i] = ch[rand.Intn(len(ch))]
-	}
-	return b
-}
-
-func mqttVarIntLen(value int) int {
-	c := 0
-	for ; value > 0; value >>= 7 {
-		c++
-	}
-	return c
-}
-
-func mqttPublishLen(topic string, qos byte, retained bool, msg []byte) int {
-	// Compute len (will have to add packet id if message is sent as QoS>=1)
-	pkLen := 2 + len(topic) + len(msg)
-	if qos > 0 {
-		pkLen += 2
-	}
-	return 1 + mqttVarIntLen(pkLen) + pkLen
-}
-
 func defaultTopic() string { return Name + "/" + nuid.Next() }
-
-func logOp(clientID, op string, dur time.Duration, f string, args ...interface{}) {
-	log.Printf("%8s %-6s %30s\t"+f, append([]any{
-		fmt.Sprintf("%.3fms", float64(dur)/float64(time.Millisecond)),
-		op,
-		clientID + ":"},
-		args...)...)
-}

--- a/publish.go
+++ b/publish.go
@@ -18,39 +18,55 @@ import (
 	"log"
 	"strconv"
 	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
 )
 
-// Message options
-type messageOpts struct {
-	qos    int
-	retain bool
-	size   int
-	topic  string
-}
-
 type publisher struct {
-	messageOpts
-
-	mps      int
-	messages int
-	topics   int
-	clientID string
+	clientID  string
+	dials     []dial
+	messages  int    // send this many messages
+	mps       int    // send at this rate (messages per second)
+	qos       int    // MQTT QOS
+	retain    bool   // Mark each published message as retained
+	size      int    // Approximate size of each message (may add a timestamp)
+	timestamp bool   // Prepend a timestamp to each message
+	topic     string // Base topic (prefix) to publish into (/{n} will be added if --topics > 0)
+	topics    int    // Cycle through this many topics appending "/{n}"
 }
 
-func (p *publisher) publish(msgCh chan *Stat, errorCh chan error, timestamp bool) {
-	cl, _, cleanup, err := connect(p.clientID, CleanSession)
-	if err != nil {
-		log.Fatal(err)
+func (p *publisher) publish(doneCh chan struct{}) {
+	defer func() {
+		if doneCh != nil {
+			doneCh <- struct{}{}
+		}
+	}()
+
+	// Connect to all servers.
+	clients := make([]paho.Client, len(p.dials))
+	for i, d := range p.dials {
+		id := p.clientID
+		if len(p.dials) > 1 {
+			id = p.clientID + "-" + strconv.Itoa(i)
+		}
+
+		cl, cleanup, err := connect(dial(d), id, CleanSession)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cleanup()
+		clients[i] = cl
 	}
-	defer cleanup()
 
-	opts := cl.OptionsReader()
 	start := time.Now()
-	var elapsed time.Duration
-	bc := 0
 	iTopic := 0
-
+	iServer := 0
 	for n := 0; n < p.messages; n++ {
+		// Get a round-robin client.
+		i := iServer % len(p.dials)
+		iServer++
+		d := dial(p.dials[i])
+		cl := clients[i]
 		now := time.Now()
 		if n > 0 && p.mps > 0 {
 			next := start.Add(time.Duration(n) * time.Second / time.Duration(p.mps))
@@ -61,7 +77,7 @@ func (p *publisher) publish(msgCh chan *Stat, errorCh chan error, timestamp bool
 		// is always terminated with a '-', which can not be part of the random
 		// fill. payload is then filled to the requested size with random data.
 		payload := randomPayload(p.size)
-		if timestamp {
+		if p.timestamp {
 			structuredPayload, _ := json.Marshal(PubValue{
 				Seq:       n,
 				Timestamp: time.Now().UnixNano(),
@@ -75,27 +91,22 @@ func (p *publisher) publish(msgCh chan *Stat, errorCh chan error, timestamp bool
 		}
 
 		currTopic := p.topic
-		if p.topics > 0 {
+		if p.topics > 1 {
 			currTopic = p.topic + "/" + strconv.Itoa(iTopic)
 			iTopic = (iTopic + 1) % p.topics
 		}
 
 		startPublish := time.Now()
 		if token := cl.Publish(currTopic, byte(p.qos), p.retain, payload); token.Wait() && token.Error() != nil {
-			errorCh <- token.Error()
+			log.Fatal(token.Error())
 			return
 		}
+
 		elapsedPublish := time.Since(startPublish)
-		elapsed += elapsedPublish
-		logOp(opts.ClientID(), "PUB <-", elapsedPublish, "Published: %d bytes to %q, qos:%v, retain:%v", len(payload), currTopic, p.qos, p.retain)
-		bc += mqttPublishLen(currTopic, byte(p.qos), p.retain, payload)
+		pubBytes := mqttPublishLen(currTopic, byte(p.qos), p.retain, payload)
+		opts := cl.OptionsReader()
+
+		recordOp(opts.ClientID(), d, "pub", 1, elapsedPublish, pubBytes, "<- Published: %d bytes to %q, qos:%v, retain:%v", pubBytes, currTopic, p.qos, p.retain)
 	}
 
-	if msgCh != nil {
-		msgCh <- &Stat{
-			Ops:   p.messages,
-			NS:    map[string]time.Duration{"pub": elapsed},
-			Bytes: int64(bc),
-		}
-	}
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,152 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type PubValue struct {
+	Seq       int   `json:"seq"`
+	Timestamp int64 `json:"timestamp"`
+}
+
+func randomPayload(sz int) []byte {
+	const ch = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@$#%^&*()"
+	b := make([]byte, sz)
+	for i := range b {
+		b[i] = ch[rand.Intn(len(ch))]
+	}
+	return b
+}
+
+func mqttVarIntLen(value int) int {
+	c := 0
+	for ; value > 0; value >>= 7 {
+		c++
+	}
+	return c
+}
+
+func mqttPublishLen(topic string, qos byte, retained bool, msg []byte) int64 {
+	// Compute len (will have to add packet id if message is sent as QoS>=1)
+	pkLen := 2 + len(topic) + len(msg)
+	if qos > 0 {
+		pkLen += 2
+	}
+	return int64(1 + mqttVarIntLen(pkLen) + pkLen)
+}
+
+type dial string
+
+func (d dial) parse() (u, p, s, c string) {
+	in := string(d)
+	if in == "" {
+		return "", "", DefaultServer, ""
+	}
+
+	if i := strings.LastIndex(in, "#"); i != -1 {
+		c = in[i+1:]
+		in = in[:i]
+	}
+
+	if i := strings.LastIndex(in, "@"); i != -1 {
+		up := in[:i]
+		in = in[i+1:]
+		u = up
+		if i := strings.Index(up, ":"); i != -1 {
+			u = up[:i]
+			p = up[i+1:]
+		}
+	}
+
+	s = in
+	return u, p, s, c
+}
+
+func (d dial) String() string {
+	u, _, s, c := d.parse()
+	if c != "" {
+		return c
+	}
+	if u == "" {
+		return s
+	} else {
+		return u + ":****@" + s
+	}
+}
+
+var disconnectedWG = sync.WaitGroup{}
+
+var Stats = make(map[string]*Stat)
+var statsMu = new(sync.Mutex)
+
+func recordOp(clientID string, d dial, name string, n int, dur time.Duration, bytes int64, f string, args ...any) {
+	statsMu.Lock()
+	stat, ok := Stats[name]
+	if !ok {
+		stat = new(Stat)
+		Stats[name] = stat
+	}
+	stat.NS += dur
+	stat.Ops += n
+	stat.Bytes += bytes
+	statsMu.Unlock()
+
+	log.Printf("%8s %-6s %30s\t"+f, append([]any{
+		fmt.Sprintf("%.3fms", float64(dur)/float64(time.Millisecond)),
+		strings.ToUpper(name),
+		clientID + "/" + d.String() + ":"},
+		args...)...)
+}
+
+func printTotals() {
+	statsMu.Lock()
+	defer statsMu.Unlock()
+
+	if len(Stats) == 0 {
+		return
+	}
+	b, _ := json.MarshalIndent(Stats, "", "  ")
+	os.Stdout.Write(b)
+}
+
+func dials(ss []string) []dial {
+	d := make([]dial, 0, len(ss))
+	for _, s := range ss {
+		d = append(d, dial(s))
+	}
+	return d
+}
+
+func waitN(doneCh chan struct{}, N int, comment string) {
+	if N == 0 {
+		N = 1
+	}
+	for n := 0; n < N; n++ {
+		select {
+		case <-time.After(Timeout):
+			log.Fatal("Error: timeout waiting for ", comment)
+		case <-doneCh:
+			// one is done
+		}
+	}
+}


### PR DESCRIPTION
(PR submitted early for self-review and to refer from nats-server)

##### Added
- all tests
  - `--timeout` to specify the test timeout, default 10s
- `sub`
  - `--timestamp`  to specify if publisher timestamps in the message body are expected and should be used to calculate the "receive" time.
- `pubsub`, `subret`
  - `--mps` for the publisher is now exposed
  - `--pub-server` allows to specify which servers are to be used for publishing (if different from `--server`s)
  - `--topics` (in `pubsub`) allows to spread messages over multiple topics, still a single `topic/+` subscriber

##### Refactored
...the code, improved message synchronization in `subret`